### PR TITLE
Open telemetry implementation

### DIFF
--- a/apps/backend/bun.lock
+++ b/apps/backend/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^14.1.1",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.203.0",
         "@opentelemetry/auto-instrumentations-node": "^0.62.1",
         "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",

--- a/apps/backend/bun.lock
+++ b/apps/backend/bun.lock
@@ -9,6 +9,7 @@
         "@opentelemetry/auto-instrumentations-node": "^0.62.1",
         "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
+        "@opentelemetry/exporter-prometheus": "^0.203.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
         "@opentelemetry/instrumentation-cassandra-driver": "^0.49.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.13.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,6 +29,7 @@
     "@opentelemetry/auto-instrumentations-node": "^0.62.1",
     "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
+    "@opentelemetry/exporter-prometheus": "^0.203.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
     "@opentelemetry/instrumentation-cassandra-driver": "^0.49.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.13.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^14.1.1",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.203.0",
     "@opentelemetry/auto-instrumentations-node": "^0.62.1",
     "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -9,6 +9,9 @@ import cors from "cors";
 import { trace, context, metrics } from "@opentelemetry/api";
 import { sdk } from "./otel/index";
 import type { ErrorRequestHandler } from "express";
+import { logs } from "@opentelemetry/api-logs";
+
+const logger = logs.getLogger("backend-logger");
 
 // ------------------------------------------------------
 // Metrics
@@ -27,7 +30,16 @@ app.use(cors());
 
 // Healthcheck route (for readiness & tracing validation)
 app.get("/health", (req, res) => {
-  res.status(200).json({ status: "ok" });
+  logger.emit({
+    severityText: "INFO",
+    body: "💓 Health check pinged",
+    attributes: {
+      path: "/health",
+      status: 200,
+    },
+  });
+
+  res.json({ status: "ok" });
 });
 
 // Middleware to trace all HTTP requests

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -24,6 +24,11 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 
+// Healthcheck route (for readiness & tracing validation)
+app.get("/health", (req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 // Middleware to trace all HTTP requests
 app.use((req, res, next) => {
   const tracer = trace.getTracer("backend");
@@ -31,7 +36,7 @@ app.use((req, res, next) => {
     attributes: {
       "http.method": req.method,
       "http.route": req.path,
-      "http.url": req.url,
+      "http.url": req.originalUrl,
     },
   });
 
@@ -50,11 +55,20 @@ app.use((req, res, next) => {
   });
 });
 
-// Kafka connections
-connectProducer();
-connectConsumer();
+// Error handling middleware (to trace uncaught errors)
+app.use((err, req, res, next) => {
+  const span = trace.getSpan(context.active());
+  if (span) {
+    span.recordException(err);
+    span.setStatus({ code: 2, message: err.message }); // 2 = ERROR
+  }
+  console.error("❌ Unhandled Error:", err);
+  res.status(500).json({ error: "Internal Server Error" });
+});
 
+// ------------------------------------------------------
 // OpenAPIBackend setup
+// ------------------------------------------------------
 const api = new OpenAPIBackend({
   definition: path.join(__dirname, "../spec/index.yml"),
   handlers: {
@@ -72,14 +86,18 @@ app.use((req, res) => api.handleRequest(req as OpenAPIRequest, req, res));
 // Main entrypoint
 // ------------------------------------------------------
 async function main() {
-  await sdk.start(); // ✅ Start OpenTelemetry SDK before server
+  await sdk.start(); // ✅ Start OpenTelemetry SDK before any instrumentation
+
+  // Start Kafka connections (after OTel)
+  connectProducer();
+  connectConsumer();
 
   const PORT = process.env.PORT || 5000;
   const server = app.listen(PORT, () => {
     console.log(`🚀 Backend running at http://localhost:${PORT}`);
   });
 
-  // Graceful shutdown
+  // Graceful shutdown for Docker / Prod
   for (const sig of ["SIGINT", "SIGTERM"] as const) {
     process.on(sig, async () => {
       console.log(`📦 Caught ${sig}, shutting down...`);

--- a/apps/backend/src/otel/index.ts
+++ b/apps/backend/src/otel/index.ts
@@ -1,69 +1,55 @@
-import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
-import { Resource } from "@opentelemetry/resources";
-import { SemanticResourceAttributes as R } from "@opentelemetry/semantic-conventions";
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { MeterProvider, PeriodicExportingMetricReader, AggregationTemporality } from "@opentelemetry/sdk-metrics";
-import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
-import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
-import { z } from "zod";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 
-if (process.env.NODE_ENV !== "production") {
-  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
-}
+import { ConsoleSpanExporter, BatchSpanProcessor, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-node";
+import { ConsoleMetricExporter, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { ConsoleLogRecordExporter, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs";
 
-const Env = z.object({
-  OTEL_SERVICE_NAME: z.string().min(1),
-  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url(),
-  OTEL_TRACES_SAMPLER: z.enum(["always_on", "always_off", "traceidratio"]).default("always_on"),
-  OTEL_RESOURCE_ATTRIBUTES: z.string().optional(),
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+
+import { logs } from "@opentelemetry/api-logs";
+import { metrics } from "@opentelemetry/api";
+
+// ------------------------------------------------------
+// Resource
+// ------------------------------------------------------
+const resource = resourceFromAttributes({
+  [SemanticResourceAttributes.SERVICE_NAME]: "my-backend",
+  [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: process.env.NODE_ENV || "development",
 });
 
-const env = Env.parse({
-  OTEL_SERVICE_NAME: process.env.OTEL_SERVICE_NAME,
-  OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  OTEL_TRACES_SAMPLER: process.env.OTEL_TRACES_SAMPLER,
-  OTEL_RESOURCE_ATTRIBUTES: process.env.OTEL_RESOURCE_ATTRIBUTES,
-});
+// ------------------------------------------------------
+// Console Exporters
+// ------------------------------------------------------
+const traceExporter = new ConsoleSpanExporter();
+const metricExporter = new ConsoleMetricExporter();
+const logExporter = new ConsoleLogRecordExporter();
 
-const deployment =
-  /(?:^|,)deployment\.environment=([^,]+)/.exec(env.OTEL_RESOURCE_ATTRIBUTES ?? "")?.[1] ?? "dev";
-
-const resource = new Resource({
-  [R.SERVICE_NAME]: env.OTEL_SERVICE_NAME,
-  [R.SERVICE_NAMESPACE]: "apps",
-  [R.SERVICE_VERSION]: "0.1.0",
-  [R.DEPLOYMENT_ENVIRONMENT]: deployment,
-});
-
-export const tracerProvider = new NodeTracerProvider({ resource });
-tracerProvider.addSpanProcessor(
-  new BatchSpanProcessor(new OTLPTraceExporter({ url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces` }))
-);
-tracerProvider.register();
-
-export const meterProvider = new MeterProvider({ resource });
-meterProvider.addMetricReader(
-  new PeriodicExportingMetricReader({
-    exporter: new OTLPMetricExporter({
-      url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`,
-      temporalityPreference: AggregationTemporality.CUMULATIVE,
+// ------------------------------------------------------
+// SDK
+// ------------------------------------------------------
+export const sdk = new NodeSDK({
+  resource,
+  spanProcessors: [new BatchSpanProcessor(traceExporter)],
+  traceSampler: new TraceIdRatioBasedSampler(1.0),
+  metricReaders: [
+    new PeriodicExportingMetricReader({
+      exporter: metricExporter,
     }),
-    exportIntervalMillis: 5000,
-  })
-);
+  ],
+  logRecordProcessors: [
+    new SimpleLogRecordProcessor(logExporter),
+  ],
+  instrumentations: [
+    ...getNodeAutoInstrumentations(),
+    new PrismaInstrumentation(),
+  ],
+});
 
-export const loggerProvider = new LoggerProvider({ resource });
-loggerProvider.addLogRecordProcessor(
-  new BatchLogRecordProcessor(new OTLPLogExporter({ url: `${env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs` }))
-);
-
-export async function shutdownTelemetry() {
-  await Promise.allSettled([
-    tracerProvider.shutdown(),
-    meterProvider.shutdown(),
-    loggerProvider.shutdown(),
-  ]);
-}
+// ------------------------------------------------------
+// Optional logger + meter instances
+// ------------------------------------------------------
+export const logger = logs.getLogger("my-backend", "1.0.0");
+export const meter = metrics.getMeter("my-backend", "1.0.0");

--- a/apps/backend/src/otel/logger.ts
+++ b/apps/backend/src/otel/logger.ts
@@ -1,40 +1,40 @@
-import { loggerProvider } from "./index";
-import { context, trace } from "@opentelemetry/api";
-import { z } from "zod";
+// import { loggerProvider } from "./index";
+// import { context, trace } from "@opentelemetry/api";
+// import { z } from "zod";
 
-const otelLogger = loggerProvider.getLogger("backend");
+// const otelLogger = loggerProvider.getLogger("backend");
 
-const LogSchema = z.object({
-  level: z.enum(["debug", "info", "warn", "error"]),
-  msg: z.string(),
-  event: z.string().optional(),
-  http: z
-    .object({
-      method: z.string().optional(),
-      route: z.string().optional(),
-      status: z.number().int().optional(),
-    })
-    .optional(),
-  user: z.object({ id: z.string().optional() }).optional(),
-});
+// const LogSchema = z.object({
+//   level: z.enum(["debug", "info", "warn", "error"]),
+//   msg: z.string(),
+//   event: z.string().optional(),
+//   http: z
+//     .object({
+//       method: z.string().optional(),
+//       route: z.string().optional(),
+//       status: z.number().int().optional(),
+//     })
+//     .optional(),
+//   user: z.object({ id: z.string().optional() }).optional(),
+// });
 
-type LogFields = z.infer<typeof LogSchema>;
+// type LogFields = z.infer<typeof LogSchema>;
 
-function traceContext() {
-  const span = trace.getSpan(context.active());
-  const sc = span?.spanContext();
-  return sc ? { trace_id: sc.traceId, span_id: sc.spanId, sampled: sc.traceFlags === 1 } : {};
-}
+// function traceContext() {
+//   const span = trace.getSpan(context.active());
+//   const sc = span?.spanContext();
+//   return sc ? { trace_id: sc.traceId, span_id: sc.spanId, sampled: sc.traceFlags === 1 } : {};
+// }
 
-export function log(fields: LogFields) {
-  const parsed = LogSchema.parse(fields);
-  const record = { ...parsed, ...traceContext(), ts: new Date().toISOString() };
-  console.log(JSON.stringify(record)); // mirror to stdout (optional)
-  otelLogger.emit({
-    body: JSON.stringify(record),
-    attributes: {
-      "log.level": record.level,
-      "log.event": record.event ?? "",
-    },
-  });
-}
+// export function log(fields: LogFields) {
+//   const parsed = LogSchema.parse(fields);
+//   const record = { ...parsed, ...traceContext(), ts: new Date().toISOString() };
+//   console.log(JSON.stringify(record)); // mirror to stdout (optional)
+//   otelLogger.emit({
+//     body: JSON.stringify(record),
+//     attributes: {
+//       "log.level": record.level,
+//       "log.event": record.event ?? "",
+//     },
+//   });
+// }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -13,13 +13,15 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     restart: unless-stopped
+    networks:
+      - observability
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
     ports: 
       - "2181:2181"
+    networks:
+      - observability
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -32,6 +34,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - observability
 
   cassandra:
     image: cassandra:4.1
@@ -44,6 +48,8 @@ services:
       CASSANDRA_NUM_TOKENS: 8
     volumes:
       - cassandra-data:/var/lib/cassandra
+    networks:
+      - observability
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -51,19 +57,24 @@ services:
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml:ro
     ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
-      - "8889:8889"   # Prometheus scrape (Collector metrics exporter)
+      - "4317:4317"
+      - "4318:4318"
+      - "8889:8889"
     restart: unless-stopped
+    networks:
+      - observability
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
+    image: jaegertracing/all-in-one:1.57
+    container_name: jaeger
     ports:
-      - "16686:16686" # Jaeger UI
-      - "14250:14250" # gRPC ingest (from Collector)
-    restart: unless-stopped
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - observability
 
   loki:
     image: grafana/loki:2.9.8
@@ -71,27 +82,35 @@ services:
     ports:
       - "3100:3100"
     restart: unless-stopped
+    networks:
+      - observability
 
   prometheus:
-    image: prom/prometheus:latest
-    volumes:
-      - ./prometheus.yaml:/etc/prometheus/prometheus.yml:ro
-    command: ["--config.file=/etc/prometheus/prometheus.yml"]
+    image: prom/prometheus
+    container_name: prometheus
     ports:
       - "9090:9090"
-    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    networks:
+      - observability
 
   grafana:
-    image: grafana/grafana:latest
-    environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin
-    volumes:
-      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+    image: grafana/grafana
+    container_name: grafana
     ports:
-      - "3001:3000"
-    depends_on: [prometheus, loki, jaeger]
-    restart: unless-stopped
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - observability
 
 volumes:
   pgdata:
   cassandra-data:
+
+networks:
+  observability:
+    driver: bridge

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -13,15 +13,13 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     restart: unless-stopped
-    networks:
-      - observability
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
     ports: 
       - "2181:2181"
-    networks:
-      - observability
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -34,8 +32,6 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-    networks:
-      - observability
 
   cassandra:
     image: cassandra:4.1
@@ -48,8 +44,6 @@ services:
       CASSANDRA_NUM_TOKENS: 8
     volumes:
       - cassandra-data:/var/lib/cassandra
-    networks:
-      - observability
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -57,24 +51,20 @@ services:
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml:ro
     ports:
-      - "4317:4317"
-      - "4318:4318"
-      - "8889:8889"
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+      - "8889:8889"   # Prometheus scrape (Collector metrics exporter)
     restart: unless-stopped
-    networks:
-      - observability
 
   jaeger:
     image: jaegertracing/all-in-one:1.57
     container_name: jaeger
     ports:
-      - "16686:16686"
-      - "4317:4317"
-      - "4318:4318"
+      - "16686:16686"   # Jaeger UI
+      - "4317:4317"     # OTLP gRPC (not used here)
+      - "4318:4318"     # OTLP HTTP (what you'll use)
     environment:
       - COLLECTOR_OTLP_ENABLED=true
-    networks:
-      - observability
 
   loki:
     image: grafana/loki:2.9.8
@@ -82,8 +72,6 @@ services:
     ports:
       - "3100:3100"
     restart: unless-stopped
-    networks:
-      - observability
 
   prometheus:
     image: prom/prometheus
@@ -94,8 +82,6 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
-    networks:
-      - observability
 
   grafana:
     image: grafana/grafana
@@ -104,13 +90,7 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
-    networks:
-      - observability
 
 volumes:
   pgdata:
   cassandra-data:
-
-networks:
-  observability:
-    driver: bridge

--- a/infra/prometheus.yaml
+++ b/infra/prometheus.yaml
@@ -1,8 +1,0 @@
-global:
-  scrape_interval: 10s
-  evaluation_interval: 10s
-
-scrape_configs:
-  - job_name: "otel-collector"
-    static_configs:
-      - targets: ["otel-collector:8889"]

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'ordexa-backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['host.docker.internal:9464']


### PR DESCRIPTION
This pull request refactors the OpenTelemetry (OTel) setup in the backend, improves error handling, and adds a healthcheck endpoint. The main focus is on simplifying and modernizing OTel configuration, ensuring correct initialization order, and enhancing observability and reliability of the backend service.

**OpenTelemetry refactor and instrumentation:**

* Replaces the custom OTel setup in `apps/backend/src/otel/index.ts` with the higher-level `NodeSDK`, using console exporters for traces, metrics, and logs, and adds auto-instrumentation and Prisma instrumentation for better coverage.
* Sets up service resource attributes in a more straightforward way and exposes optional logger and meter instances for use elsewhere in the codebase.

**Startup and initialization improvements:**

* Ensures the OTel SDK is started before any instrumentation or Kafka connections, to guarantee all telemetry is captured from the start.

**Observability and error handling:**

* Adds a `/health` endpoint for readiness checks and tracing validation, which responds with status `ok`.
* Introduces error-handling middleware to record uncaught exceptions in OTel traces and return a 500 error response, improving debugging and reliability.

**Kafka connection timing:**

* Moves Kafka producer and consumer connection initialization to after OTel SDK startup, ensuring their activity is properly traced.